### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker Automated buil](https://img.shields.io/docker/automated/workflow4metabolomics/galaxy-workflow4metabolomics.svg?maxAge=2592000)](https://hub.docker.com/r/workflow4metabolomics/galaxy-workflow4metabolomics/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/workflow4metabolomics/galaxy-workflow4metabolomics.svg?maxAge=2592000)](https://hub.docker.com/r/workflow4metabolomics/galaxy-workflow4metabolomics/)
-[![Docker Stars](https://img.shields.io/docker/stars/workflow4metabolomics/galaxy-workflow4metabolomics.svg?maxAge=2592000)](https://hub.docker.com/r/workflow4metabolomics/galaxy-workflow4metabolomics/)
+[![Docker Stars](https://img.shields.io/docker/stars/workflow4metabolomics/galaxy-workflow4metabolomics.svg?maxAge=2592000)](https://hub.docker.com/r/workflow4metabolomics/galaxy-workflow4metabolomics/) [![](https://images.microbadger.com/badges/image/workflow4metabolomics/galaxy-workflow4metabolomics.svg)](https://microbadger.com/images/workflow4metabolomics/galaxy-workflow4metabolomics "Get your own image badge on microbadger.com")
 [![Build Status](https://travis-ci.org/workflow4metabolomics/w4m-vm.svg?branch=travis)](https://travis-ci.org/workflow4metabolomics/w4m-vm)
 
 ![workflow](https://raw.githubusercontent.com/workflow4metabolomics/workflow4metabolomics/master/images/logo/logo-ifb-mono-metabohub_2.1_SD_150px.png)
@@ -264,3 +264,4 @@ sh manage_db.sh upgrade
 
 
 
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [workflow4metabolomics/galaxy-workflow4metabolomics](https://hub.docker.com/r/workflow4metabolomics/galaxy-workflow4metabolomics/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/workflow4metabolomics/galaxy-workflow4metabolomics).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/workflow4metabolomics/galaxy-workflow4metabolomics.svg)](https://microbadger.com/images/workflow4metabolomics/galaxy-workflow4metabolomics)
